### PR TITLE
Cache Result url

### DIFF
--- a/app/evaluation/migrations/0008_result_absolute_url.py
+++ b/app/evaluation/migrations/0008_result_absolute_url.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='result',
             name='absolute_url',
-            field=models.TextField(blank=True),
+            field=models.TextField(blank=True, editable=False),
         ),
     ]

--- a/app/evaluation/migrations/0008_result_absolute_url.py
+++ b/app/evaluation/migrations/0008_result_absolute_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('evaluation', '0007_auto_20180216_1516'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='result',
+            name='absolute_url',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/app/evaluation/models.py
+++ b/app/evaluation/models.py
@@ -364,7 +364,7 @@ class Result(UUIDModel):
     # Cache the url as this is slow on the results list page
     absolute_url = models.TextField(
         blank=True,
-        editable=True,
+        editable=False,
     )
 
     def get_absolute_url(self):

--- a/app/evaluation/models.py
+++ b/app/evaluation/models.py
@@ -361,6 +361,12 @@ class Result(UUIDModel):
         ),
     )
 
+    # Cache the url as this is slow on the results list page
+    absolute_url = models.TextField(
+        blank=True,
+        editable=True,
+    )
+
     def get_absolute_url(self):
         return reverse('evaluation:result-detail',
                        kwargs={

--- a/app/evaluation/signals.py
+++ b/app/evaluation/signals.py
@@ -52,6 +52,15 @@ def recalculate_ranks(sender: Result, instance: Union[Result, Config] = None,
     calculate_ranks.apply_async(kwargs={'challenge_pk': instance.challenge.pk})
 
 
+@receiver(post_save, sender=Result)
+def cache_absolute_url(sender: Result, instance: Result = None,
+                       created: bool = False, **kwargs):
+    """Cache the absolute url to speed up the results page, needs the pk of
+    the result so cannot so into a custom save method"""
+    Result.objects.filter(pk=instance.pk).update(
+        absolute_url=instance.get_absolute_url())
+
+
 # TODO: do we really want to generate an API token for all users? Only admins surely
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def create_auth_token(sender: settings.AUTH_USER_MODEL,

--- a/app/evaluation/templates/evaluation/job_detail.html
+++ b/app/evaluation/templates/evaluation/job_detail.html
@@ -27,7 +27,7 @@
             href="{{ object.method.get_absolute_url }}">{{ object.method.pk }}</a>
     </p>
     <p><b>Result:</b> <a
-            href="{{ object.result.get_absolute_url }}">{{ object.result.pk }}</a>
+            href="{{ object.result.absolute_url }}">{{ object.result.pk }}</a>
     </p>
     <p><b>Output:</b>
         {{ object.output }}

--- a/app/evaluation/templates/evaluation/job_list.html
+++ b/app/evaluation/templates/evaluation/job_list.html
@@ -49,7 +49,7 @@
                 {% if job.output %}
                     <td>{{ job.output|user_error }}</td>
                 {% elif job.result.metrics %}
-                    <td><a href="{{ job.result.get_absolute_url }}">Result</a></td>
+                    <td><a href="{{ job.result.absolute_url }}">Result</a></td>
                 {% else %}
                     <td></td>
                 {% endif %}

--- a/app/evaluation/templates/evaluation/result_list.html
+++ b/app/evaluation/templates/evaluation/result_list.html
@@ -32,8 +32,10 @@
         </thead>
         <tbody>
         {% for result in object_list %}
-            <tr class='clickable-row' data-url='{{ result.get_absolute_url }}'>
+            <tr>
+
                 <td>{{ result.rank }}</td>
+
                 <td>
                     <div style='vertical-align:middle; display:inline;'>
                         <a href="{% url 'userena_profile_detail' result.job.submission.creator %}">
@@ -46,7 +48,7 @@
                 </td>
                 <td data-order="{{ result.created|date:"U" }}">{{ result.created }}</td>
 
-                <td>{{ result.metrics|get_jsonpath:site.evaluation_config.score_jsonpath|floatformat:"-4" }}</td>
+                <td><a href="{{ result.absolute_url }}">{{ result.metrics|get_jsonpath:site.evaluation_config.score_jsonpath|floatformat:"-4" }}</a></td>
 
                 {% for _, jsonpath in site.evaluation_config.extra_results_columns.items %}
                     <td>{{ result.metrics|get_jsonpath:jsonpath|floatformat:"-4" }}</td>
@@ -88,10 +90,6 @@
                     "orderable": false
                 }],
                 ordering: true
-            });
-
-            $(".clickable-row").on('click', function () {
-                window.location = $(this).data('url');
             });
 
         });

--- a/app/evaluation/templates/evaluation/submission_form.html
+++ b/app/evaluation/templates/evaluation/submission_form.html
@@ -32,7 +32,7 @@
 
     <h2>View my submissions</h2>
 
-    <p>Click <a href="{% url 'evaluation:job-list' site.short_name %}">here</a>
+    <p><a href="{% url 'evaluation:job-list' site.short_name %}">Click here</a>
         to view your current submissions to this challenge.</p>
 
 {% endblock %}


### PR DESCRIPTION
The get_absolute_url method makes a single database query, so this takes
a long time on the results list view. Therefore, cache the url and
store it on the object. This will cache until the next Result object
save, so will everything will need to be updated if the ComicSite
short_name changes, or the results object url changes.